### PR TITLE
Add option for binned histogram data

### DIFF
--- a/packages/core/src/configuration.ts
+++ b/packages/core/src/configuration.ts
@@ -608,12 +608,15 @@ const bulletChart: BulletChartOptions = merge({}, axisChart, {
  * options specific to stacked bar charts
  */
 const histogramChart: HistogramChartOptions = merge({}, baseBarChart, {
-	bars: {
-		dividerSize: 1.5
-	} as StackedBarOptions,
-	timeScale: merge(timeScale, {
-		addSpaceOnEdges: 0
-	} as TimeScaleOptions)
+        bars: {
+                dividerSize: 1.5
+        } as StackedBarOptions,
+        data: merge(chart.data, {
+                countMapsTo: 'count'
+        }),
+        timeScale: merge(timeScale, {
+                addSpaceOnEdges: 0
+        } as TimeScaleOptions)
 } as BarChartOptions)
 
 /*

--- a/packages/core/src/interfaces/charts.ts
+++ b/packages/core/src/interfaces/charts.ts
@@ -119,16 +119,21 @@ export interface BaseChartOptions {
 	/**
 	 * options related to charting data
 	 */
-	data?: {
-		/**
-		 * identifier for data groups
-		 */
-		groupMapsTo?: string
-		/**
-		 * used to simulate data loading in skeleton way
-		 */
-		loading?: boolean
-		/**
+        data?: {
+                /**
+                 * identifier for data groups
+                 */
+                groupMapsTo?: string
+                /**
+                 * identifier for counts in pre-binned data
+                 * (defaults to 'count')
+                 */
+                countMapsTo?: string
+                /**
+                 * used to simulate data loading in skeleton way
+                 */
+                loading?: boolean
+                /**
 		 * options related to pre-selected data groups
 		 * Remains empty if every legend item is active or dataset doesn't have the data groups.
 		 */

--- a/packages/core/src/model/model.ts
+++ b/packages/core/src/model/model.ts
@@ -225,9 +225,18 @@ export class ChartModel {
 		return activeDataGroups.map((dataGroup: any) => dataGroup.name)
 	}
 
-	private aggregateBinDataByGroup(bin: any) {
-		return groupBy(bin, 'group')
-	}
+       private aggregateBinDataByGroup(bin: any) {
+               const options = this.getOptions()
+               const countKey = getProperty(options, 'data.countMapsTo')
+               const { groupMapsTo } = options.data
+               const totals: any = {}
+               bin.forEach((d: any) => {
+                       const group = d[groupMapsTo]
+                       const count = countKey ? Number(d[countKey] ?? 0) : 1
+                       totals[group] = (totals[group] ?? 0) + count
+               })
+               return totals
+       }
 
 	getBinConfigurations() {
 		// Manipulate data and options for Histogram
@@ -386,21 +395,26 @@ export class ChartModel {
 		const dataGroupNames = this.getDataGroupNames()
 
 		const stackKeys = this.getStackKeys({ bins, groups })
-		if (bins) {
-			return stackKeys.map((key: any) => {
-				const [binStart, binEnd] = key.split(':')
+               if (bins) {
+                       const countKey = getProperty(options, 'data.countMapsTo')
+                       return stackKeys.map((key: any) => {
+                               const [binStart, binEnd] = key.split(':')
 
-				const correspondingValues: any = { x0: binStart, x1: binEnd }
-				const correspondingBin = bins.find((bin: any) => bin.x0.toString() === binStart.toString())
-				dataGroupNames.forEach((dataGroupName: any) => {
-					correspondingValues[dataGroupName] = correspondingBin.filter(
-						(binItem: any) => binItem[groupMapsTo] === dataGroupName
-					).length
-				})
+                               const correspondingValues: any = { x0: binStart, x1: binEnd }
+                               const correspondingBin = bins.find((bin: any) => bin.x0.toString() === binStart.toString())
+                               dataGroupNames.forEach((dataGroupName: any) => {
+                                       const items = correspondingBin.filter(
+                                               (binItem: any) => binItem[groupMapsTo] === dataGroupName
+                                       )
+                                       correspondingValues[dataGroupName] = items.reduce(
+                                               (sum: number, item: any) => sum + (countKey ? Number(item[countKey] ?? 0) : 1),
+                                               0
+                                       )
+                               })
 
-				return correspondingValues
-			}) as any
-		}
+                               return correspondingValues
+                       }) as any
+               }
 
 		return stackKeys.map((key: any) => {
 			const correspondingValues: any = { sharedStackKey: key }

--- a/packages/core/src/model/model.ts
+++ b/packages/core/src/model/model.ts
@@ -1,5 +1,5 @@
 import { bin as d3Bin, scaleOrdinal, stack, stackOffsetDiverging } from 'd3'
-import { cloneDeep, fromPairs, groupBy, merge, uniq } from 'lodash-es'
+import { cloneDeep, fromPairs, merge, uniq } from 'lodash-es'
 import { getProperty, updateLegendAdditionalItems } from '@/tools'
 import { color as colorConfigs, legend as legendConfigs } from '@/configuration'
 import { histogram as histogramConfigs } from '@/configuration-non-customizable'


### PR DESCRIPTION
## Summary
- revert prior attempt at binned histogram chart
- allow histograms to read a `countMapsTo` field
- aggregate bin counts without expanding data

## Testing
- `yarn lint` *(fails: 66 errors, 1431 warnings)*
- `yarn test` *(fails to complete)*
